### PR TITLE
Add Missing Page to Sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -78,7 +78,11 @@ const sidebars = {
             id: 'mission-modeling/activity-types/introduction',
             type: 'doc',
           },
-          items: ['mission-modeling/activity-types/parameters', 'mission-modeling/activity-types/effect-model'],
+          items: [
+            'mission-modeling/activity-types/parameters',
+            'mission-modeling/activity-types/effect-model',
+            'mission-modeling/activity-types/durations'
+          ],
         },
         'mission-modeling/resources-and-models',
         'mission-modeling/configuration',


### PR DESCRIPTION
The page on activity duration types was missing from `sidebar.js`, making it undiscoverable. This has been fixed. Additionally, I check that the rest of our docs are currently accessible form the sidebar.