### PR TITLE
Add API Docs for Altair Playground Login

### DIFF
--- a/docs/api/assets/api-playground-admin-secret.mov
+++ b/docs/api/assets/api-playground-admin-secret.mov
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce3914cb1baa1963297b0cc293bfbadf8f3b7d8ee695175afddb2ff1b39ea1b5
+size 2121965

--- a/docs/api/assets/api-playground-headers.png
+++ b/docs/api/assets/api-playground-headers.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c22d0e4baa3868e56cb8fa26754dca671ca6cfbc1e45b1b4d41ac1a20415103e
-size 565176

--- a/docs/api/assets/api-playground-pre-request-script.mov
+++ b/docs/api/assets/api-playground-pre-request-script.mov
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79eddeb20cf03fa9fb0ad8ce0398c5ac7a7ed318805ce45fc44b69a1e5984600
+size 2768358

--- a/docs/api/introduction.mdx
+++ b/docs/api/introduction.mdx
@@ -1,7 +1,8 @@
 import apiPlayground from './assets/api-playground.png';
-import apiPlaygroundHeaders from './assets/api-playground-headers.png';
 import gatewayAuthLogin from './assets/gateway-auth-login.png';
 import hasuraConsoleLogin from './assets/hasura-console-login.png';
+import adminSecretPlayground from './assets/api-playground-admin-secret.mov';
+import preRequestScript from './assets/api-playground-pre-request-script.mov';
 
 # Introduction
 
@@ -116,6 +117,18 @@ If you are using Aerie locally, or have the [admin secret](https://hasura.io/doc
 
 Since a GraphQL API has more underlying structure than a REST API, there are a range of methods by which a client application may choose to interact with the API. A simple usage could use the [curl](https://curl.se/) command line tool, whereas a full featured web application may integrate a more powerful client library like [Apollo Client](https://www.apollographql.com/docs/react/) or [Relay](https://relay.dev/) which automatically handle query building, batching and caching.
 
+<details>
+<summary>The Hasura Console</summary>
+
+Previously our recommendation was to use the Hasura Console to explore the Aerie API. As of Aerie `1.7.0` the Hasura Console requires the admin secret to access, which makes it unavailable to most for non-local use cases.
+If you have the admin secret you can still use the Hasura Console by supplying the secret on the login page.
+
+<figure align="center">
+  <img alt="Aerie Hasura Console - Admin Login" src={hasuraConsoleLogin} />
+  <figcaption>Figure 4: Aerie Hasura Console - Admin Login</figcaption>
+</figure>
+</details>
+
 ### Playground
 
 Aerie provides an API playground via the [Altair](https://altairgraphql.dev/) GraphQL client. You can use the playground user interface to query the Aerie API directly. It is a great way to start exploring Aerie data and get familiar with GraphQL. If you are running Aerie locally you can view the playground (via the gateway server) at [http://localhost:9000/api-playground/](http://localhost:9000/api-playground/) (change the `localhost` domain as needed).
@@ -125,19 +138,71 @@ Aerie provides an API playground via the [Altair](https://altairgraphql.dev/) Gr
   <figcaption>Figure 2: Aerie API Playground - Altair</figcaption>
 </figure>
 
-To use the API playground you need to set the proper authorization header (either `Authorization` or `x-hasura-admin-secret` - see the [Authentication section above](#authentication)). Here is an example on how to set either one in the playground:
+To use the API playground you need to set the proper authorization header (either `Authorization` or `x-hasura-admin-secret` - see the [Authentication section above](#authentication)).
 
-<figure align="center">
-  <img alt="Aerie API Playground - Altair Authorization Headers" src={apiPlaygroundHeaders} />
-  <figcaption>Figure 3: Aerie API Playground - Altair Authorization Headers</figcaption>
-</figure>
+#### Admin Secret
 
-Previously our recommendation was to use the Hasura Console to explore the Aerie API. As of Aerie `1.7.0` the Hasura Console requires the admin secret to access, which makes it unavailable to most for non-local use cases. If you have the admin secret you can still use the Hasura Console by supplying the secret on the login page.
+Access the Global Environment by clicking on "No Environment" -> "Environments..." in the top-right of the page.
+Set it to the following:
 
-<figure align="center">
-  <img alt="Aerie Hasura Console - Admin Login" src={hasuraConsoleLogin} />
-  <figcaption>Figure 4: Aerie Hasura Console - Admin Login</figcaption>
-</figure>
+```json
+{
+  "headers" :
+  {
+    "x-hasura-admin-secret": "<YOUR_ADMIN_SECRET>",
+    "x-hasura-user-id": "<YOUR_AERIE_USERNAME>",
+    "x-hasura-role": "viewer"
+  }
+}
+```
+
+<video controls>
+  <source src={adminSecretPlayground} />
+</video>
+
+#### Authorization
+
+If you do not know the admin secret for your venue, you can instead run a pre-request script to authorize yourself against the Gateway.
+
+1. Access the Global Environment by clicking on "No Environment" -> "Environments..." in the top-right of the page.
+Set it to the following:
+```json
+{
+  "headers" :
+  {
+    "Authorization": "Bearer {{user}}",
+    "x-hasura-role": "viewer"
+  }
+}
+```
+
+2. In the Query Window, click on Pre-request. Select Enable Pre-request script.
+
+
+3. Enter the following pre-request script:
+```js
+// Fetch a new token from the Gateway
+const res = await altair.helpers.request(
+  'POST',
+  '<GATEWAY_URL>/auth/login', // AUTH ENDPOINT OF THE DEPLOYMENT
+  {
+    body: { "username": "<YOUR_AERIE_USERNAME>", "password": "<YOUR_AERIE_PASSWORD>"}, // CREDENTIALS TO LOG IN AS
+    headers: {"Content-Type": "application/json"}
+  });
+if(res.success) {
+  const token = res.token;
+  await altair.helpers.setEnvironment("user", token);
+} else {
+  altair.log(res);
+}
+```
+
+The Playground will now automatically fetch an updated token before each query.
+To learn more about pre-request scripts, visit [the Altair GQL docs](https://altairgraphql.dev/docs/features/prerequest-scripts.html).
+
+<video controls>
+  <source src={preRequestScript} />
+</video>
 
 ### Python
 


### PR DESCRIPTION
Adds instructions for how to write a pre-request script to automatically log the user in to the API Playground.

If we upgrade the version of Altair GQL on the Gateway, this script can be refined so that it only logs in when the old token is expired, as opposed to once per query (the version we're using doesn't let us use local storage to keep the token between requests).