### PR TITLE
Add Plan Snapshot Docs

### DIFF
--- a/docs/api/examples/planning/introduction.mdx
+++ b/docs/api/examples/planning/introduction.mdx
@@ -61,9 +61,7 @@ The `start_time` is in the [day-of-year](https://nsidc.org/data/user-resources/h
 
 :::info
 
-If you want to run **simulation** against your plan you need to [update the simulation configuration](../../simulation#update-a-simulation-configuration) with the bounds you want to run simulation over.
-
-If you want to run **scheduling** against your plan you need to [create an associated scheduling specification](../../scheduling#create-scheduling-specification) respectively.
+If you want to run **scheduling** against your plan you need to [create an associated scheduling specification](../../scheduling#create-scheduling-specification).
 
 :::
 

--- a/docs/api/examples/planning/snapshots.mdx
+++ b/docs/api/examples/planning/snapshots.mdx
@@ -1,0 +1,74 @@
+# Snapshots
+
+A snapshot of a plan is a named record of the state of all activities in a plan at a certain time.
+Snapshots are useful for recording and returning to known "good" states of a plan.
+
+## Taking a Snapshot
+
+```graphql
+mutation createSnapshot($planId: Int!, $snapshotName: String!, $description: String) {
+  create_snapshot(args: {
+      _plan_id: $planId,
+      _snapshot_name: $snapshotName,
+      _description: $description
+  }) {
+    snapshot_id
+  }
+}
+```
+
+Below is an example set of query variables for this function. Note that `description` is optional and may be excluded.
+
+```json
+{
+  "planId": 1,
+  "snapshotName": "Snapshot of My Plan",
+  "description": "Optional description for this snapshot"
+}
+```
+
+## Tagging a Snapshot
+
+[Tags](../../tags) can be applied to snapshots.
+
+### Adding a Tag
+
+```graphql
+mutation AddPlanSnapshotTag($snapshotId:Int!, $tagId: Int!){
+  insert_plan_snapshot_tags_one(object: {snapshot_id: $snapshotId, tag_id: $tagId}) {
+    plan_snapshot {
+      snapshot_name
+      description
+    }
+    tag {
+      name
+      color
+      owner
+    }
+  }
+}
+```
+
+### Removing a Tag
+
+```graphql
+mutation RemovePlanSnapshotTag($snapshotId: Int!, $tagId: Int!) {
+  delete_plan_snapshot_tags_by_pk(snapshot_id: $snapshotId, tag_id: $tagId) {
+    plan_snapshot {
+      snapshot_name
+      description
+    }
+    tag { name }
+  }
+}
+```
+
+## Restoring a Snapshot
+
+```graphql
+mutation restoreSnapshot($planId: Int!, $snapshotId: Int!) {
+  restore_from_snapshot(args: {_plan_id: $planId, _snapshot_id: $snapshotId}) {
+    snapshot_id
+  }
+}
+```

--- a/docs/api/examples/tags.md
+++ b/docs/api/examples/tags.md
@@ -1,0 +1,52 @@
+# Tags
+
+Tags are metadata that can be used to mark certain things in Aerie, including Plans, Plan Snapshots, Activity Directives, Scheduling Goals, Constraints, and Command Expansion Runs. 
+Tags are shared across an Aerie instance.
+
+## Creating a Tag
+
+```graphql
+mutation CreateTag($name: String!, $color: String) {
+  insert_tags_one(object: {name: $name, color: $color}) {
+    id
+    name
+    color
+  }
+}
+```
+
+The `color` field is optional, however, if specified, it must be a hex color code. 
+This field is used to determine what color the tag appears as when displayed in the UI.
+
+## Updating a Tag
+
+```graphql
+mutation UpdateTag($tagId: Int!, $set: tags_set_input!) {
+  update_tags_by_pk(pk_columns: {id: $tagId}, _set: $set) {
+    id
+    name
+    color
+    owner
+  }
+}
+```
+
+The `set` object is a JSON containing any of the following fields:
+ - `name`: the new name for the tag
+ - `owner`: the new owner of the tag
+ - `color`: either `null` or a hex color code
+
+## Deleting a Tag
+
+```graphql
+mutation DeleteTag($tagId: Int!) {
+  delete_tags_by_pk(id: $tagId) {
+    id
+    name
+    color
+    owner
+  }
+}
+```
+
+

--- a/docs/api/introduction.mdx
+++ b/docs/api/introduction.mdx
@@ -72,7 +72,7 @@ To interact with the API you need to be authenticated. For each request Hasura r
 
 To get a token from the gateway UI you can visit [http://localhost:9000/#/Auth/post_auth_login](http://localhost:9000/#/Auth/post_auth_login), and enter your JPL username and password (change `localhost` do your deployment URL if you are running Aerie on a different domain).
 
-<figure align="center">
+<figure>
   <img alt="Aerie Gateway UI - Auth Login" src={gatewayAuthLogin} />
   <figcaption>Figure 1: Aerie Gateway UI - Auth Login</figcaption>
 </figure>
@@ -123,7 +123,7 @@ Since a GraphQL API has more underlying structure than a REST API, there are a r
 Previously our recommendation was to use the Hasura Console to explore the Aerie API. As of Aerie `1.7.0` the Hasura Console requires the admin secret to access, which makes it unavailable to most for non-local use cases.
 If you have the admin secret you can still use the Hasura Console by supplying the secret on the login page.
 
-<figure align="center">
+<figure>
   <img alt="Aerie Hasura Console - Admin Login" src={hasuraConsoleLogin} />
   <figcaption>Figure 4: Aerie Hasura Console - Admin Login</figcaption>
 </figure>
@@ -133,7 +133,7 @@ If you have the admin secret you can still use the Hasura Console by supplying t
 
 Aerie provides an API playground via the [Altair](https://altairgraphql.dev/) GraphQL client. You can use the playground user interface to query the Aerie API directly. It is a great way to start exploring Aerie data and get familiar with GraphQL. If you are running Aerie locally you can view the playground (via the gateway server) at [http://localhost:9000/api-playground/](http://localhost:9000/api-playground/) (change the `localhost` domain as needed).
 
-<figure align="center">
+<figure>
   <img alt="Aerie API Playground - Altair" src={apiPlayground} />
   <figcaption>Figure 2: Aerie API Playground - Altair</figcaption>
 </figure>

--- a/docs/command-expansion/expansion-rules.mdx
+++ b/docs/command-expansion/expansion-rules.mdx
@@ -15,9 +15,7 @@ Click on "New" above the table to the right to create a new expansion rule.
 
 <figure>
   <img alt="Aerie UI - Expansion Rules Page" src={rulesPage} />
-  <figcaption align="center">
-    Figure 1: Aerie UI Expansion Rules Page - View, create, or delete expansion rules
-  </figcaption>
+  <figcaption>Figure 1: Aerie UI Expansion Rules Page - View, create, or delete expansion rules</figcaption>
 </figure>
 
 ## Authoring
@@ -29,7 +27,7 @@ Once the activity type is selected, its parameters can be accessed within the ex
 
 <figure>
   <img alt="Aerie UI - Expansion Rules Editor" src={rulesEditor} />
-  <figcaption align="center">Figure 2: Aerie UI Expansion Rules Editor</figcaption>
+  <figcaption>Figure 2: Aerie UI Expansion Rules Editor</figcaption>
 </figure>
 
 An expansion rule starts with some boilerplate code, and users are expected to add their commands as comma-separated objects in a `return []` statement structured as the following:
@@ -53,12 +51,12 @@ Values for ENUMs will be listed as strings, and must be input as strings. See th
 
 <figure>
   <img alt="Aerie UI Expansion Rules Editor - Command Autocomplete" src={rulesEditorCommandAutocomplete} />
-  <figcaption align="center">Figure 3: Aerie UI Expansion Rules Editor - Command Autocomplete</figcaption>
+  <figcaption>Figure 3: Aerie UI Expansion Rules Editor - Command Autocomplete</figcaption>
 </figure>
 
 <figure>
   <img alt="Aerie UI Expansion Rules Editor - Command Arguments Error" src={rulesEditorCommandArgsError} />
-  <figcaption align="center">Figure 4: Aerie UI Expansion Rules Editor - Command Arguments Error</figcaption>
+  <figcaption>Figure 4: Aerie UI Expansion Rules Editor - Command Arguments Error</figcaption>
 </figure>
 
 The true power of command expansion is to be able to map activity parameter values to command arguments.
@@ -71,9 +69,7 @@ Note that expansion request will replace these with actual values from simulated
 <figure>
   <img alt="Aerie UI Expansion Rules Editor - Command Arguments for Activity" src={rulesEditorCommandArgs1} />
   <img alt="Aerie UI Expansion Rules Editor - Command Arguments for Activity" src={rulesEditorCommandArgs2} />
-  <figcaption align="center">
-    Figure 5: Aerie UI Expansion Rules Editor - Passing Command Arguments from Activity
-  </figcaption>
+  <figcaption>Figure 5: Aerie UI Expansion Rules Editor - Passing Command Arguments from Activity</figcaption>
 </figure>
 
 Expansion rules can also access computed attributes of an activity.

--- a/docs/command-expansion/expansion-sets.mdx
+++ b/docs/command-expansion/expansion-sets.mdx
@@ -18,7 +18,7 @@ To create a new expansion set click the "New" button on the upper right corner o
 
 <figure>
   <img alt="Aerie UI - Expansion Sets Page" src={setsPage} />
-  <figcaption align="center">Figure 1: Aerie UI Expansion Sets Page - View or delete expansion sets</figcaption>
+  <figcaption>Figure 1: Aerie UI Expansion Sets Page - View or delete expansion sets</figcaption>
 </figure>
 
 :::info
@@ -35,7 +35,7 @@ In the figure below users can select as many activity types, but must select a s
 
 <figure>
   <img alt="Aerie UI - Expansion Sets Create Page" src={setsCreatePage} />
-  <figcaption align="center">Figure 2: Aerie UI Expansion Sets Create Page</figcaption>
+  <figcaption>Figure 2: Aerie UI Expansion Sets Create Page</figcaption>
 </figure>
 
 :::info

--- a/docs/command-expansion/run-expansion.mdx
+++ b/docs/command-expansion/run-expansion.mdx
@@ -8,7 +8,7 @@ Once the expansion set is selected, clicking on the "Expand" button in the upper
 
 <figure>
   <img alt="Aerie UI - Plan Run Expansion" src={planRunExpansion} />
-  <figcaption align="center">Figure 1: Plan Run Expansion </figcaption>
+  <figcaption>Figure 1: Plan Run Expansion </figcaption>
 </figure>
 
 ## Viewing Expansion Results
@@ -17,5 +17,5 @@ Once expansion is complete, users can view the resulting sequence in the seqJSON
 
 <figure>
   <img alt="Aerie UI - Plan View Sequence" src={planViewSequence} />
-  <figcaption align="center">Figure 2: Plan View Sequence </figcaption>
+  <figcaption>Figure 2: Plan View Sequence </figcaption>
 </figure>

--- a/docs/command-expansion/sequences.mdx
+++ b/docs/command-expansion/sequences.mdx
@@ -11,7 +11,7 @@ To do so users should first open the "Expansion" panel in the [Aerie Planning UI
 
 <figure>
   <img alt="Aerie UI - Plan Expansion Panel" src={planExpansionPanel} />
-  <figcaption align="center">Figure 1: Plan Expansion Panel </figcaption>
+  <figcaption>Figure 1: Plan Expansion Panel </figcaption>
 </figure>
 
 ## Adding Sequences to a Simulation Dataset
@@ -37,7 +37,7 @@ To declare a new sequence, simply type the seqID and press "Create".
 
 <figure>
   <img alt="Aerie UI - Plan Create Sequence" src={planCreateSequence} />
-  <figcaption align="center">Figure 2: Plan Create Sequence </figcaption>
+  <figcaption>Figure 2: Plan Create Sequence </figcaption>
 </figure>
 
 ## Assigning seqIDs to Simulated Activities

--- a/docs/command-expansion/upload-command-dictionary.mdx
+++ b/docs/command-expansion/upload-command-dictionary.mdx
@@ -16,14 +16,14 @@ Aerie does not allow uploading the command dictionary files that has the same mi
 
 <figure>
   <img alt="Aerie UI - Navigation Menu" src={navigationMenuPng} />
-  <figcaption align="center">
+  <figcaption>
     Figure 1: Aerie UI Navigation Menu - Click to the 'Command Dictionaries' menu item
   </figcaption>
 </figure>
 
 <figure>
   <img alt="Aerie UI - Command Dictionary Page" src={commandDictionaryPagePng} />
-  <figcaption align="center">
+  <figcaption>
     Figure 2: Aerie UI Command Dictionary Page - View, upload, or delete AMPCS command dictionaries
   </figcaption>
 </figure>

--- a/docs/deployment/advanced-authentication.mdx
+++ b/docs/deployment/advanced-authentication.mdx
@@ -48,9 +48,9 @@ The default Aerie [docker-compose.yml](https://github.com/NASA-AMMOS/aerie/blob/
 
 ## Aerie UI Login Page
 
-With CAM authentication enabled you can login to the Aerie UI with your JPL username and password.
+With CAM authentication enabled you can log in to the Aerie UI with your JPL username and password.
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Login Page" src={uiLoginPage} />
   <figcaption>Figure 1: Aerie UI - Login Page</figcaption>
 </figure>

--- a/docs/overview/concept-of-operations.mdx
+++ b/docs/overview/concept-of-operations.mdx
@@ -87,7 +87,7 @@ Aerie is an extensible framework designed to cover as many key steps in the plan
 
 import aerieCapabilities from './assets/aerie-capabilities.png';
 
-<figure align="center">
+<figure>
   <img alt="Current Aerie Capabilities" src={aerieCapabilities} />
   <figcaption>Aerie offers a wide range of capabilities</figcaption>
 </figure>
@@ -102,7 +102,7 @@ Aerie is a planning and simulation tool powered by a discrete event simulation e
 
 import missionModel from './assets/mission-model.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie mission model" src={missionModel} />
   <figcaption>Aerie mission model</figcaption>
 </figure>
@@ -111,7 +111,7 @@ Activity type as a planning unit, is comprised of parameters that modulate its b
 
 import activityType from './assets/activity-type.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie activity type" src={activityType} width="300" />
   <figcaption>Aerie activity type</figcaption>
 </figure>
@@ -120,7 +120,7 @@ Once a mission model is available, creating plans and running simulations can be
 
 import startingWithAerie from './assets/starting-with-aerie.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie steps to simulation" src={startingWithAerie} />
   <figcaption>Steps required to run your first simulation in Aerie</figcaption>
 </figure>

--- a/docs/overview/software-design-document.mdx
+++ b/docs/overview/software-design-document.mdx
@@ -79,8 +79,9 @@ A](#a---the-c4-model).
 
 import c4AerieContext from './assets/c4-aerie-context.png';
 
-<figure align="center">
-  <img alt="Aerie Context" src={c4AerieContext} width="512" /> <figcaption>Figure 1: Aerie Context</figcaption>
+<figure>
+  <img alt="Aerie Context" src={c4AerieContext} width="512" />
+  <figcaption>Figure 1: Aerie Context</figcaption>
 </figure>
 
 Aerie is designed to be incrementally evolvable - so that it can more
@@ -117,7 +118,7 @@ merlin-worker has a direct connection to the merlin database.
 
 import c4AerieContainer from './assets/c4-aerie-container.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie Container" src={c4AerieContainer} width="700" />
   <figcaption>Figure 2: Aerie Composition at the Container Level</figcaption>
 </figure>
@@ -406,7 +407,7 @@ defining mission models in a file system.
 
 import c4MerlinServerComponent from './assets/c4-merlin-server-component.png';
 
-<figure align="center">
+<figure>
   <img alt="Merlin Server Component" src={c4MerlinServerComponent} width="700" />
   <figcaption>Figure 3: The Component Diagram for Merlin Server</figcaption>
 </figure>
@@ -1297,7 +1298,7 @@ aspects:
 
 import c4SchedulingComponent from './assets/c4-scheduling-component.png';
 
-<figure align="center">
+<figure>
   <img alt="Scheduling Component" src={c4SchedulingComponent} width="400" />
   <figcaption>Figure 4: The Aerie Scheduling Component</figcaption>
 </figure>

--- a/docs/planning/advanced-extensions.mdx
+++ b/docs/planning/advanced-extensions.mdx
@@ -30,7 +30,7 @@ If there are no any extensions registered, this entry will be hidden.
 Hovering over extensions will bring up the list of registered Extensions.
 To run an extension, click on its entry in the list.
 
-<figure align="center">
+<figure>
   <img alt="Aerie Planning Navbar - Extensions" src={extensions} />
   <figcaption>Figure 1: Aerie Planning Navbar - Extensions</figcaption>
 </figure>

--- a/docs/planning/advanced-incons.mdx
+++ b/docs/planning/advanced-incons.mdx
@@ -24,12 +24,8 @@ They may need to be tweaked slightly depending on how your model implemented inc
 Navigate to your deployment's Hasura GraphQL console by selecting `GraphQL Console` in the dropdown under `Aerie`.
 By default, the GraphQL console is accessible on [port 8080](http://localhost:8080).
 
-<figure align="center">
-  <img
-    alt="Aerie UI - Dropdown Menu Highlighting GraphQL Console Option"
-    src={gqlDropdown}
-    style={{ maxHeight: '50vh' }}
-  />
+<figure>
+  <img alt="Aerie UI - Dropdown Menu Highlighting GraphQL Console Option" src={gqlDropdown} />
   <figcaption>Figure 1: Dropdown Menu Highlighting GraphQL Console Option</figcaption>
 </figure>
 
@@ -68,7 +64,7 @@ If the first time a resource's value is set is after `start_offset`, it will not
 
 :::
 
-<video controls align="center">
+<video controls>
   <source src={simulationInconsQuery} type="video/webm" />
 </video>
 
@@ -79,8 +75,8 @@ Take the value of `"getResourcesAtStartOffset"` from the output of the query and
 Next, navigate to your deployment's Gateway by selecting `Gateway` in the dropdown under `Aerie`.
 By default, the Gateway is accessible on [port 9000](http://localhost:9000).
 
-<figure align="center">
-  <img alt="Aerie UI - Dropdown Menu Highlighting Gateway Option" src={gatewayDropdown} style={{ maxHeight: '50vh' }} />
+<figure>
+  <img alt="Aerie UI - Dropdown Menu Highlighting Gateway Option" src={gatewayDropdown}/>
   <figcaption>Figure 2: Dropdown Menu Highlighting Gateway Option</figcaption>
 </figure>
 
@@ -110,7 +106,7 @@ Click the `Execute` button. In `ServerResponse`, you should see a response body 
 
 The most important element of this JSON is `filename`. It contains the name of the file within Aerie.
 
-<video controls align="center">
+<video controls>
   <source src={uploadIncons} type="video/webm" />
 </video>
 
@@ -122,6 +118,6 @@ and `<filename>` is the value of `"filename"` from the earlier JSON from the Gat
 
 By default, `<path-to-aerie-file-store>` is `merlin_file_store`.
 
-<video controls align="center">
+<video controls>
   <source src={simulateIncons} type="video/webm" />
 </video>

--- a/docs/planning/anchors.mdx
+++ b/docs/planning/anchors.mdx
@@ -42,14 +42,14 @@ A plan **cannot** be simulated or scheduled while there are invalid anchors.
 
 If an activity directive has an invalid anchor, the error message can be viewed by hovering over the problematic field in the `Selected Activity` pane.
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Anchor Validation Error in a Tooltip" src={invalidAnchorTooltip} />
   <figcaption>Figure 1: Aerie UI - Anchor Validation Error in a Tooltip</figcaption>
 </figure>
 
 To see a full list of the invalid anchors for a plan, select the `Anchor Validation Errors` tab from the Error Console
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Anchor Validation Errors in the Error Console" src={invalidAnchorsList} />
   <figcaption>Figure 2: Aerie UI - Anchor Validation Errors in the Error Console</figcaption>
 </figure>

--- a/docs/planning/assets/snapshots/planMetadataPane.png
+++ b/docs/planning/assets/snapshots/planMetadataPane.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:211adcf2161d1dae217a58f83506d23ee4f3f4d747e6aee528f7f482ecf8eda4
+size 145986

--- a/docs/planning/assets/snapshots/restoreSnapshotModal.png
+++ b/docs/planning/assets/snapshots/restoreSnapshotModal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31e0f1861cbc6ed853906305a6ada3cfb221bd0fdcccfc374d6218795c729aac
+size 41987

--- a/docs/planning/assets/snapshots/restoreSnapshotTakeSnapshot.png
+++ b/docs/planning/assets/snapshots/restoreSnapshotTakeSnapshot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b85de39ad83e6d6dc7a503cdde49997e1fadaafad3c18f3fb5a1a5d9a8fe56cd
+size 69251

--- a/docs/planning/assets/snapshots/takeSnapshotModal.png
+++ b/docs/planning/assets/snapshots/takeSnapshotModal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8098539fb50bc5fa235bac659a173de08f58a94fc19b84bf0fb9d904500ec85c
+size 71496

--- a/docs/planning/assets/snapshots/takeSnapshotNavbar.png
+++ b/docs/planning/assets/snapshots/takeSnapshotNavbar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5b0a80e968ad4fab457c541c8c80d6492e20acb485711a435a43a7d17326761
+size 56999

--- a/docs/planning/assets/snapshots/viewSnapshot.png
+++ b/docs/planning/assets/snapshots/viewSnapshot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c30847cde99938ea7b8fe3917c031fb04bf914b05a8c3f57b90420fee108a421
+size 668036

--- a/docs/planning/assets/snapshots/viewSnapshotNavbar.png
+++ b/docs/planning/assets/snapshots/viewSnapshotNavbar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac2a5b018534e96ac580dcd950bdc8a9a7784aa3ce97cf1e777a0c99f5e36fca
+size 56804

--- a/docs/planning/collaboration/introduction.mdx
+++ b/docs/planning/collaboration/introduction.mdx
@@ -33,7 +33,7 @@ To learn how to do plan collaboration via the Aerie API, see our [API documentat
 
 When on a plan in the Aerie UI, select the drop-down from beside the plan's name and select "Create branch":
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Create Plan Branch Menu" src={createBranchMenu} />
   <figcaption>Figure 1: Aerie UI - Create Plan Branch Menu</figcaption>
 </figure>
@@ -41,14 +41,14 @@ When on a plan in the Aerie UI, select the drop-down from beside the plan's name
 That will open a modal where you can enter the new branch's name.
 Selecting "Create Branch" will open the new branch:
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Create Plan Branch Modal" src={createBranchModal} />
   <figcaption>Figure 2: Aerie UI - Create Plan Branch Modal</figcaption>
 </figure>
 
 To return to the parent plan, either click the parent plan's name or select "Open parent plan" from the dropdown:
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Open Parent Plan" src={openParentPlan} />
   <figcaption>Figure 3: Aerie UI - Open Parent Plan</figcaption>
 </figure>
@@ -56,7 +56,7 @@ To return to the parent plan, either click the parent plan's name or select "Ope
 To return to a branch from the parent plan, click the 1 branch text from beside the name of the plan.
 Then select the plan from the list of branches:
 
-<figure align="center">
+<figure>
   <div>
     <img alt="Aerie UI - Open Branch Header" src={openBranchHeader} />
   </div>

--- a/docs/planning/collaboration/merging-plans.mdx
+++ b/docs/planning/collaboration/merging-plans.mdx
@@ -11,10 +11,8 @@ Confirm which plan you wish to be the target plan and press "Create merge reques
 import createMergeRq from './assets/create-merge-rq.png';
 import createMergeRqModal from './assets/create-merge-rq-modal.png';
 
-<figure align="center">
-  <div>
-    <img alt="Aerie UI - Create Merge Request Menu" src={createMergeRq} />
-  </div>
+<figure>
+  <img alt="Aerie UI - Create Merge Request Menu" src={createMergeRq} />
   <img alt="Aerie UI - Create Merge Request" src={createMergeRqModal} />
   <figcaption>Figure 1: Aerie UI - Create Merge Request</figcaption>
 </figure>
@@ -37,7 +35,7 @@ Then, press the "Withdraw" button next to the merge request you wish to withdraw
 import outgoingMergeRequests from './assets/outgoing-merge-rqs.png';
 import withdrawMergeRequestModal from './assets/withdraw-merge-rq-modal.png';
 
-<figure align="center">
+<figure>
   <div>
     <img alt="Aerie UI - Outgoing Merge Requests" src={outgoingMergeRequests} />
   </div>
@@ -61,7 +59,7 @@ Then, press "Review" next to the merge request you wish to begin:
 import incomingMergeRequests from './assets/incoming-merge-rqs.png';
 import beginMergeModal from './assets/begin-merge-modal.png';
 
-<figure align="center">
+<figure>
   <div>
     <img alt="Aerie UI - Incoming Merge Requests" src={incomingMergeRequests} />
   </div>
@@ -75,7 +73,7 @@ You can cancel any `in-progress` merge. From the merge review screen, press the 
 
 import cancelMerge from './assets/cancel-merge.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Cancel Merge" src={cancelMerge} />
   <figcaption>Figure 4: Aerie UI - Cancel Merge</figcaption>
 </figure>
@@ -91,12 +89,12 @@ Then, determine which version to keep by pressing either "Keep Source Activity" 
 import unresolvedConflict from './assets/unresolved-conflict.png';
 import resolvedConflict from './assets/resolved-conflict.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Unresolved Conflict" src={unresolvedConflict} />
   <figcaption>Figure 5: Aerie UI - Unresolved Merge Conflict</figcaption>
 </figure>
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Resolved Conflict" src={resolvedConflict} />
   <figcaption>Figure 6: Aerie UI - Resolved Merge Conflict</figcaption>
 </figure>
@@ -105,7 +103,7 @@ You can also resolve conflicts in bulk:
 
 import resolveConflictsBulk from './assets/resolve-conflicts-bulk.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Resolve Merge Conflicts in Bulk" src={resolveConflictsBulk} />
   <figcaption>Figure 7: Aerie UI - Resolve Merge Conflicts in Bulk</figcaption>
 </figure>
@@ -119,7 +117,7 @@ From the merge review screen, press the "Deny Changes" button in the bottom-righ
 
 import denyMerge from './assets/deny-merge.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Deny Merge" src={denyMerge} />
   <figcaption>Figure 8: Aerie UI - Deny Merge</figcaption>
 </figure>
@@ -131,7 +129,7 @@ From the merge review screen, press the "Approve Changes" button in the bottom-r
 
 import approveMerge from './assets/approve-merge.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Approve Merge" src={approveMerge} />
   <figcaption>Figure 9: Aerie UI - Approve Merge</figcaption>
 </figure>

--- a/docs/planning/snapshots.mdx
+++ b/docs/planning/snapshots.mdx
@@ -1,0 +1,81 @@
+import takeSnapshotNavbar from './assets/snapshots/takeSnapshotNavbar.png';
+import takeSnapshotModal from './assets/snapshots/takeSnapshotModal.png';
+
+import viewSnapshotNavbar from './assets/snapshots/viewSnapshotNavbar.png';
+import planMetadataPane from './assets/snapshots/planMetadataPane.png';
+import viewSnapshot from './assets/snapshots/viewSnapshot.png';
+
+import restoreSnapshotModal from './assets/snapshots/restoreSnapshotModal.png';
+import restoreAndTakeSnapshot from './assets/snapshots/restoreSnapshotTakeSnapshot.png';
+
+# Snapshots
+
+A snapshot of a plan is a named record of the state of all activities in a plan at a certain time.
+Snapshots are useful for recording and returning to known "good" states of a plan.
+
+<!--
+:::info
+
+If you are looking to create a record of a simulation configuration, see Simulation Presets.
+
+If you are looking to create a reusable set of arguments on a single activity, see Activity Presets.
+
+:::
+-->
+
+## Taking a Snapshot
+
+Snapshots can via one of two methods:
+1. Clicking on the Plan's name in the navbar, then clicking "Take Snapshot"
+2. Clicking on the "Take Snapshot" button in the Plan Metadata Pane
+
+Either option will then present you with a modal where you can name the snapshot and optionally provide a description and tags.
+Note that snapshot names must be unique per plan.
+
+<figure>
+  <div>
+    <img alt="Aerie UI - Expanded drop down under Plan in the Navbar, the option 'Take Snapshot' is highlighted" src={takeSnapshotNavbar}/>
+  </div>
+  <img alt="Aerie UI - Take Snapshot Modal" src={takeSnapshotModal}/>
+  <figcaption>Figure 1: Aerie UI - How to Take a Plan Snapshot</figcaption>
+</figure>
+
+
+## Viewing a Snapshot
+
+You can view the snapshots taken for a specific plan by clicking on the Plan's name in the navbar, then clicking "View Snapshot History".
+Doing so will open the Plan Metadata Pane, where a list of all snapshots taken will be displayed.
+If a snapshot has been simulated, an icon will be present indicating the results of the most recent simulation for that snapshot.
+
+You can filter this list to only display snapshots for the currently selected simulation dataset by selecting the "Snapshot" badge to the left of the "Take Snapshot" button.
+
+<figure>
+  <div>
+    <img alt="Aerie UI - Expanded drop down under Plan in the Navbar, the option 'View Snapshot' is highlighted" src={viewSnapshotNavbar}/>
+  </div>
+  <img alt="Aerie UI - Plan Metadata Pane" src={planMetadataPane}/>
+  <figcaption>Figure 2: Aerie UI - How to View a Plan Snapshot</figcaption>
+</figure>
+
+Clicking on a snapshot will open a preview of its contents. From here, you can examine activities and related simulation datasets.
+
+<figure>
+  <img alt="Aerie UI - Take Snapshot Modal" src={viewSnapshot}/>
+  <figcaption>Figure 3: Aerie UI - Viewing a Plan Snapshot</figcaption>
+</figure>
+
+## Restoring a Snapshot
+
+If you would like to update a plan to match the state of a snapshot, you can do so by clicking on the "Restore Snapshot" button seen while previewing a snapshot.
+
+When restoring a snapshot, you can optionally choose to take a snapshot of the current state of the plan prior to restoring.
+
+<figure>
+  <div>
+    <img alt="Aerie UI - Restore Snapshot Modal" src={restoreSnapshotModal}/>
+  </div>
+  <img alt="Aerie UI - Restore and Take Snapshot Modal - Simple" src={restoreAndTakeSnapshot}/>
+  <figcaption>Figure 4: Aerie UI - How to Restore a Plan Snapshot</figcaption>
+</figure>
+
+The snapshot you restored will remain in the list in case you need to restore to it again in the future.

--- a/docs/planning/timeline-editing.mdx
+++ b/docs/planning/timeline-editing.mdx
@@ -16,9 +16,9 @@ Edit general timeline properties from within the timeline editor panel. If multi
 Changes made in the Timeline Editor are not automatically saved and must be saved to the UI view.
 :::
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Timeline Editor" src={timelineEditor} />
-  <figcaption align="center">
+  <figcaption>
     Figure 1: Aerie UI Timeline Editor - Manage Timeline properties, Vertical Guides, and Rows
   </figcaption>
 </figure>
@@ -39,9 +39,9 @@ Click on the plus button to add a new row to the timeline. A row will be added b
 
 Edit row properties from within the timeline row editor. If multiple rows exist you can use the top dropdown to edit different rows. A blue highlight will appear around the row in the timeline that you are currently editing. You can also edit a row by clicking on the pencil icon in the header of a row in the timeline.
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Timeline Row Editor" src={timelineRowEditor} />
-  <figcaption align="center">
+  <figcaption>
     Figure 2: Aerie UI Timeline Row Editor - Manage Row properties, Horizontal Guides, Y Axes, and Layers
   </figcaption>
 </figure>

--- a/docs/scheduling/goals.mdx
+++ b/docs/scheduling/goals.mdx
@@ -536,7 +536,7 @@ This section describes how to create a new scheduling goal via the Aerie UI. In 
 
 import schedulingPanel from './assets/scheduling-panel.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Scheduling Panel" src={schedulingPanel} />
   <figcaption>Figure 1: Aerie UI Scheduling Panel</figcaption>
 </figure>
@@ -545,7 +545,7 @@ Next click "New" to create a new scheduling goal in the specification for the pl
 
 import goalEditorNew from './assets/goal-editor-new.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Scheduling Goal Editor - New Goal" src={goalEditorNew} />
   <figcaption>Figure 2: Scheduling Goal Editor - New Goal</figcaption>
 </figure>
@@ -586,7 +586,7 @@ The editor should tell you that `ActivityRecurrenceGoal()` takes one argument:
 
 import invalidRecurrenceGoal from './assets/invalid-recurrence-goal.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Invalid Recurrence Goal" src={invalidRecurrenceGoal} />
   <figcaption>Figure 3: Invalid Recurrence Goal</figcaption>
 </figure>
@@ -633,7 +633,7 @@ To delete or edit a scheduling goal via the UI, open the scheduling pane and rig
 
 import goalContextMenu from './assets/goal-context-menu.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Goal Context Menu" src={goalContextMenu} />
   <figcaption>Figure 4: Goal Context Menu</figcaption>
 </figure>
@@ -642,7 +642,7 @@ Click on "Delete Goal" to delete the goal. If you click on "Edit Goal" it will o
 
 import goalEditorEdit from './assets/goal-editor-edit.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Scheduling Goal Editor - Edit Goal" src={goalEditorEdit} />
   <figcaption>Figure 5: Scheduling Goal Editor - Edit Goal</figcaption>
 </figure>

--- a/docs/scheduling/run-scheduling.mdx
+++ b/docs/scheduling/run-scheduling.mdx
@@ -8,7 +8,7 @@ The Aerie scheduler accepts a list of goals, and tries to satisfy them one by on
 
 import schedulingSpecification from './assets/scheduling-specification.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Scheduling Specification" src={schedulingSpecification} />
   <figcaption>Figure 1: Aerie UI Scheduling Specification</figcaption>
 </figure>
@@ -35,7 +35,7 @@ To run the scheduler, click on the play button:
 
 import runScheduling from './assets/run-scheduling.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Run Scheduling" src={runScheduling} />
   <figcaption>Figure 2: Aerie UI Run Scheduling</figcaption>
 </figure>
@@ -44,7 +44,7 @@ If the scheduler fails, a failure icon will appear next to the buttons:
 
 import schedulingFailed from './assets/scheduling-failed.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Scheduling Failed" src={schedulingFailed} />
   <figcaption>Figure 3: Aerie UI Scheduling Failed</figcaption>
 </figure>
@@ -53,7 +53,7 @@ An error message will also appear in the bottom error panel. For example:
 
 import schedulingError from './assets/scheduling-error.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Scheduling Error" src={schedulingError} />
   <figcaption>Figure 4: Aerie UI Scheduling Error</figcaption>
 </figure>
@@ -62,7 +62,7 @@ If scheduling succeeded, some information about the satisfaction of the goal app
 
 import schedulingSuccess from './assets/scheduling-success.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Scheduling Success" src={schedulingSuccess} />
   <figcaption>Figure 5: Aerie UI Scheduling Success</figcaption>
 </figure>
@@ -77,7 +77,7 @@ The scheduler has an analysis mode that will evaluate the satisfaction of goals 
 
 import runSchedulingAnalysis from './assets/run-scheduling-analysis.png';
 
-<figure align="center">
+<figure>
   <img alt="Aerie UI - Scheduling Analysis" src={runSchedulingAnalysis} />
   <figcaption>Figure 6: Aerie UI Run Scheduling Analysis</figcaption>
 </figure>

--- a/docs/sequencing/editor.mdx
+++ b/docs/sequencing/editor.mdx
@@ -6,7 +6,7 @@ Navigate to the Aerie sequence editor from the Aerie drop down menu at the upper
 
 import navigateSeq from './assets/navigateSeq.png';
 
-<figure align="center">
+<figure>
   <img alt="Navigate to Aerie sequencing editor" src={navigateSeq} />
   <figcaption>Use main Aerie drop down menu to navigate to the Aerie sequence editor.</figcaption>
 </figure>
@@ -15,7 +15,7 @@ The landing page lists all sequences available at this venue in the left panel. 
 
 import viewSeq from './assets/viewSeq.png';
 
-<figure align="center">
+<figure>
   <img alt="View list of sequences" src={viewSeq} />
   <figcaption>The landing page lists all sequences that are authored.</figcaption>
 </figure>
@@ -30,7 +30,7 @@ In the sequence editing page users need to select a command dictionary before th
 
 import editSeq from './assets/editSeq.png';
 
-<figure align="center">
+<figure>
   <img alt="Edit sequence" src={editSeq} />
   <figcaption>Users can rename or edit a sequence, and view the seqJSON output. </figcaption>
 </figure>

--- a/sidebars.js
+++ b/sidebars.js
@@ -22,6 +22,7 @@ const sidebars = {
           items: [
             'api/examples/planning/collaboration',
             'api/examples/planning/anchors',
+            'api/examples/planning/snapshots'
           ],
         },
         'api/examples/simulation',

--- a/sidebars.js
+++ b/sidebars.js
@@ -119,6 +119,7 @@ const sidebars = {
           },
           items: ['planning/collaboration/merging-plans'],
         },
+        'planning/snapshots',
         'planning/anchors',
         'planning/ui-views',
         'planning/timeline-editing',

--- a/sidebars.js
+++ b/sidebars.js
@@ -29,6 +29,7 @@ const sidebars = {
         'api/examples/scheduling',
         'api/examples/activity-presets',
         'api/examples/advanced-extensions',
+        'api/examples/tags',
       ],
     },
   ],

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -48,3 +48,13 @@ video {
   height: auto !important;
   width: 100% !important;
 }
+
+figure {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+figure img {
+  max-height: 40vh;
+}


### PR DESCRIPTION
Closes #72. Includes UI docs.

Additionally:
- fixes the CSS for `figures` so that they correctly appear as centered and so that images in figures are by default restricted to a max height of `40vh`.
- adds API docs for Tags. UI docs ticket is [here](https://github.com/NASA-AMMOS/aerie-docs/issues/93)
