### PR TITLE
Publish upgrade guide for 2.6.1

### DIFF
--- a/docs/upgrade-guides/2-5-0-to-2-6-0.md
+++ b/docs/upgrade-guides/2-5-0-to-2-6-0.md
@@ -2,6 +2,9 @@
 
 This document describes the upgrade instructions from `2.5.0` to `2.6.0`.
 
+# 2.6.0 NOT RECOMMENDED
+NOTE that a migration-related bug was discovered in version `2.6.0` after release. If you have not yet upgraded to `2.6.0`, you can skip this version and upgrade directly to `2.6.1`. If you are already using `2.6.0`, you should upgrade to `2.6.1` as soon as possible to avoid potential issues. More details can be found in [this Github issue](https://github.com/NASA-AMMOS/aerie/pull/1374).
+
 # Changes to scheduling goals and conditions
 To support shared & versioned scheduling goals and conditions, several changes were made to their behavior and database structure. The goals and conditions tables have each been split into two tables, a metadata table and a definitions table. Goals and conditions may now be associated with multiple plans via plan specifications, and may be marked "public" or "private" to control their visibility to other users.
 

--- a/docs/upgrade-guides/2-6-0-to-2-6-1.md
+++ b/docs/upgrade-guides/2-6-0-to-2-6-1.md
@@ -1,0 +1,6 @@
+# 2.6.0 to 2.6.1
+
+This document describes the upgrade instructions from `2.6.0` to `2.6.1`.
+
+## Patch release
+This is a patch release to fix a known issue in `2.6.0`. If you are using `2.6.0`, you should upgrade to this version to avoid potential issues with data migration. No additional changes are necessary.

--- a/sidebars.js
+++ b/sidebars.js
@@ -324,6 +324,7 @@ const sidebars = {
     'glossary',
   ],
   upgradeGuides: [
+    'upgrade-guides/2-6-0-to-2-6-1',
     'upgrade-guides/2-5-0-to-2-6-0',
     'upgrade-guides/2-4-0-to-2-5-0',
     'upgrade-guides/2-3-0-to-2-4-0',


### PR DESCRIPTION
Same as #136 - The upgrade guide for 2.6.1 needs to be merged to `develop` so it gets published to our public docs page. 