### PR TITLE
minor updates to upgrade guides

### DIFF
--- a/docs/upgrade-guides/2-5-0-to-2-6-0.md
+++ b/docs/upgrade-guides/2-5-0-to-2-6-0.md
@@ -3,7 +3,7 @@
 This document describes the upgrade instructions from `2.5.0` to `2.6.0`.
 
 # 2.6.0 NOT RECOMMENDED
-NOTE that a migration-related bug was discovered in version `2.6.0` after release. If you have not yet upgraded to `2.6.0`, you can skip this version and upgrade directly to `2.6.1`. If you are already using `2.6.0`, you should upgrade to `2.6.1` as soon as possible to avoid potential issues. More details can be found in [this Github issue](https://github.com/NASA-AMMOS/aerie/pull/1374).
+NOTE that a migration-related bug was discovered in version `2.6.0` after release. If you have not yet upgraded to `2.6.0`, you can skip this version and upgrade directly to `2.6.2` or later. If you are already using `2.6.0`, you should upgrade to `2.6.2` or later as soon as possible to avoid potential issues. More details can be found in [this Github issue](https://github.com/NASA-AMMOS/aerie/pull/1374).
 
 # Changes to scheduling goals and conditions
 To support shared & versioned scheduling goals and conditions, several changes were made to their behavior and database structure. The goals and conditions tables have each been split into two tables, a metadata table and a definitions table. Goals and conditions may now be associated with multiple plans via plan specifications, and may be marked "public" or "private" to control their visibility to other users.

--- a/docs/upgrade-guides/2-6-0-to-2-6-1.md
+++ b/docs/upgrade-guides/2-6-0-to-2-6-1.md
@@ -2,5 +2,5 @@
 
 This document describes the upgrade instructions from `2.6.0` to `2.6.1`.
 
-## Patch release
-This is a patch release to fix a known issue in `2.6.0`. If you are using `2.6.0`, you should upgrade to this version to avoid potential issues with data migration. No additional changes are necessary.
+# 2.6.1 NOT RECOMMENDED
+NOTE that a bug was discovered in version `2.6.1` after release. If you have not yet upgraded to `2.6.1`, you can skip this version and upgrade directly to `2.6.2` or later. If you are already using `2.6.1`, you should upgrade to `2.6.2` or later as soon as possible to avoid potential issues. More details can be found in [this Github issue](https://github.com/NASA-AMMOS/aerie/pull/1401).

--- a/docs/upgrade-guides/2-6-1-to-2-6-2.md
+++ b/docs/upgrade-guides/2-6-1-to-2-6-2.md
@@ -1,0 +1,6 @@
+# 2.6.1 to 2.6.2
+
+This document describes the upgrade instructions from `2.6.1` to `2.6.2`.
+
+## Patch release
+This is a patch release to fix a known issue in `2.6.1`. If you are using `2.6.1`, you should upgrade to this version or later to avoid potential issues with data migration. No additional changes are necessary.

--- a/docs/upgrade-guides/2-6-1-to-2-7-0.md
+++ b/docs/upgrade-guides/2-6-1-to-2-7-0.md
@@ -1,7 +1,0 @@
-# 2.6.1 to 2.7.0
-
-This document describes the upgrade instructions from `2.6.1` to `2.7.0`.
-
-No upgrade steps required for 2.1.0.
-
-Some changes were made to Aerie UI dependencies. If you are running `aerie-ui` locally and have issues running the application or tests after this upgrade, try following the ["Cleaning" procedure in the Developer Guide](https://github.com/NASA-AMMOS/aerie-ui/blob/develop/docs/DEVELOPER.md#cleaning), then run `npm run build` to create a fresh build.

--- a/docs/upgrade-guides/2-6-2-to-2-7-0.md
+++ b/docs/upgrade-guides/2-6-2-to-2-7-0.md
@@ -1,0 +1,9 @@
+# 2.6.2 to 2.7.0
+
+This document describes the upgrade instructions from `2.6.2` to `2.7.0`.
+
+# 2.7.0 NOT RECOMMENDED
+NOTE that a bug was discovered in version `2.7.0` after release. If you have not yet upgraded to `2.7.0`, you can skip this version and upgrade directly to `2.7.1` or later. If you are already using `2.7.0`, you should upgrade to `2.7.1` or later as soon as possible to avoid potential issues. More details can be found in [this Github issue](https://github.com/NASA-AMMOS/aerie/pull/1401).
+
+## Dependency changes
+Some changes were made to Aerie UI dependencies. If you are running `aerie-ui` locally and have issues running the application or tests after this upgrade, try following the ["Cleaning" procedure in the Developer Guide](https://github.com/NASA-AMMOS/aerie-ui/blob/develop/docs/DEVELOPER.md#cleaning), then run `npm run build` to create a fresh build.

--- a/docs/upgrade-guides/2-7-0-to-2-7-1.md
+++ b/docs/upgrade-guides/2-7-0-to-2-7-1.md
@@ -3,4 +3,4 @@
 This document describes the upgrade instructions from `2.7.0` to `2.7.1`.
 
 ## Patch release
-This is a patch release to fix a known issue in `2.7.0`. If you are using `2.7.0`, you should upgrade to this version to avoid potential issues with data migration. No additional changes are necessary. More information about this issue can be found [here](https://github.com/NASA-AMMOS/aerie/pull/1374).
+This is a patch release to fix a known issue in `2.7.0`. If you are using `2.7.0`, you should upgrade to this version or later to avoid potential issues with data migration. No additional changes are necessary. More information about this issue can be found [here](https://github.com/NASA-AMMOS/aerie/pull/1374).

--- a/docs/upgrade-guides/2-7-1-to-2-8-0.md
+++ b/docs/upgrade-guides/2-7-1-to-2-8-0.md
@@ -19,7 +19,9 @@ Several new environment variables are now required. Compare the new version of t
 - existing values, especially AERIE_USERNAME, AERIE_PASSWORD, POSTGRES_USER and POSTGRES_PASSWORD, **must** remain unchanged from your previous version if you plan to migrate your data
 - You must fill in (arbitrary) values for the password variables, which are left blank in the released `.env` file
 
-If you plan to migrate your data, follow the [migration instructions below](#for-anyone-migrating-data-to-v280) before running Aerie v2.8.0 for the first time.
+### Other notes
+* Users should no longer run the `createSchedulingSpecification` mutation after creating a plan via the API
+* If you plan to migrate your data, follow the [migration instructions below](#for-anyone-migrating-data-to-v280) before running Aerie v2.8.0 for the first time.
 
 ## For Aerie Developers
 (ie. anyone running Aerie from a cloned version of the `aerie` repository)

--- a/sidebars.js
+++ b/sidebars.js
@@ -326,7 +326,8 @@ const sidebars = {
   upgradeGuides: [
     'upgrade-guides/2-7-1-to-2-8-0',
     'upgrade-guides/2-7-0-to-2-7-1',
-    'upgrade-guides/2-6-1-to-2-7-0',
+    'upgrade-guides/2-6-2-to-2-7-0',
+    'upgrade-guides/2-6-1-to-2-6-2',
     'upgrade-guides/2-6-0-to-2-6-1',
     'upgrade-guides/2-5-0-to-2-6-0',
     'upgrade-guides/2-4-0-to-2-5-0',


### PR DESCRIPTION
* Make sure all patch versions have upgrade guides
* "NOT RECOMMENDED" notice on all versions with known bugs & patches
* Added note re: `createSchedulingSpecification` mutation to 2.8.0 guide per suggestion from @Mythicaeda 