### PR TITLE
Keyboard shortcuts

### DIFF
--- a/docs/keyboard-shortcuts.mdx
+++ b/docs/keyboard-shortcuts.mdx
@@ -1,0 +1,66 @@
+---
+title: Keyboard Shortcuts
+---
+
+export const Shortcut = ({ children }) => (
+  <kbd
+    style={{
+      margin: '0.2rem 0rem',
+      backgroundColor: 'var(--color-secondary-lightest)',
+      // borderColor: 'var(--color-secondary-lighter)',
+    }}
+  >
+    <span>{children}</span>
+  </kbd>
+);
+
+A list of keyboard shortcuts that can be used within the Aerie UI.
+
+### Plan View
+
+**Timeline**
+
+The easiest way to zoom in and out is using <Shortcut>⌘</Shortcut> + <Shortcut>scroll</Shortcut> (MacOS) or <Shortcut>ctrl</Shortcut> + <Shortcut>scroll</Shortcut> (Windows) with the cursor over the timeline section. This works with a trackpad
+or a mouse.
+
+- <Shortcut>middle mouse button</Shortcut> + <Shortcut>drag</Shortcut> pans the timeline horizontally
+
+- <Shortcut>=</Shortcut> zooms timeline in
+- <Shortcut>-</Shortcut> zooms timeline out
+
+- <Shortcut>[</Shortcut> nudges timeline left
+- <Shortcut>]</Shortcut> nudges timeline right
+
+- <Shortcut>ctrl</Shortcut> + <Shortcut>T</Shortcut> toggles the cursor visibility
+- <Shortcut>0</Shortcut> resets the timeline zoom
+
+- <Shortcut>delete</Shortcut> or <Shortcut>backspace</Shortcut> deletes selected activity directive
+
+<br />
+
+**Activity Table**
+
+- <Shortcut>delete</Shortcut> or <Shortcut>backspace</Shortcut> delete selected row from tables you have permissions to delete
+
+<br />
+
+**Activity Parameters**
+
+- <Shortcut>⌘</Shortcut> + <Shortcut>left click</Shortcut> (MacOS) or <Shortcut>ctrl</Shortcut> + <Shortcut>
+    left click
+  </Shortcut> (Windows) resets paramater value to default
+
+<br />
+
+**Activity Error Rollup**
+
+- <Shortcut>⌘</Shortcut> + <Shortcut>left click</Shortcut> (MacOS) or <Shortcut>ctrl</Shortcut> + <Shortcut>
+    left click
+  </Shortcut> (Windows) resets invalid parameters if possible
+
+### Expansion Rule Form
+
+- <Shortcut>⌘</Shortcut> + <Shortcut>s</Shortcut> (MacOS) or <Shortcut>ctrl</Shortcut> + <Shortcut>s</Shortcut> (Windows)
+  saves the form
+
+### Sequence Editor

--- a/docs/keyboard-shortcuts.mdx
+++ b/docs/keyboard-shortcuts.mdx
@@ -16,10 +16,11 @@ A list of keyboard shortcuts that can be used within the Aerie UI.
 
 ### Plan View
 
+Start running simulation from anywhere in the plan view with <Shortcut>⌘</Shortcut> + <Shortcut>s</Shortcut> (MacOS) or <Shortcut>ctrl</Shortcut> + <Shortcut>s</Shortcut> (Windows).
+
 **Timeline**
 
-The easiest way to zoom in and out is using <Shortcut>⌘</Shortcut> + <Shortcut>scroll</Shortcut> (MacOS) or <Shortcut>ctrl</Shortcut> + <Shortcut>scroll</Shortcut> (Windows) with the cursor over the timeline section. This works with a trackpad
-or a mouse.
+The easiest way to navigate the timeline is by holding <Shortcut>⌘</Shortcut> (MacOS) or <Shortcut>ctrl</Shortcut> (Windows) and then using <Shortcut>click</Shortcut>+<Shortcut>drag</Shortcut> to pan and <Shortcut>scroll</Shortcut> to zoom in and out.
 
 - <Shortcut>middle mouse button</Shortcut> + <Shortcut>drag</Shortcut> pans the timeline horizontally
 - <Shortcut>=</Shortcut> zooms timeline in

--- a/docs/keyboard-shortcuts.mdx
+++ b/docs/keyboard-shortcuts.mdx
@@ -6,11 +6,9 @@ export const Shortcut = ({ children }) => (
   <kbd
     style={{
       margin: '0.2rem 0rem',
-      backgroundColor: 'var(--color-secondary-lightest)',
-      // borderColor: 'var(--color-secondary-lighter)',
     }}
   >
-    <span>{children}</span>
+    {children}
   </kbd>
 );
 
@@ -24,16 +22,12 @@ The easiest way to zoom in and out is using <Shortcut>⌘</Shortcut> + <Shortcut
 or a mouse.
 
 - <Shortcut>middle mouse button</Shortcut> + <Shortcut>drag</Shortcut> pans the timeline horizontally
-
 - <Shortcut>=</Shortcut> zooms timeline in
 - <Shortcut>-</Shortcut> zooms timeline out
-
 - <Shortcut>[</Shortcut> nudges timeline left
 - <Shortcut>]</Shortcut> nudges timeline right
-
 - <Shortcut>ctrl</Shortcut> + <Shortcut>T</Shortcut> toggles the cursor visibility
 - <Shortcut>0</Shortcut> resets the timeline zoom
-
 - <Shortcut>delete</Shortcut> or <Shortcut>backspace</Shortcut> deletes selected activity directive
 
 <br />
@@ -58,9 +52,16 @@ or a mouse.
     left click
   </Shortcut> (Windows) resets invalid parameters if possible
 
+<br />
+
 ### Expansion Rule Form
 
 - <Shortcut>⌘</Shortcut> + <Shortcut>s</Shortcut> (MacOS) or <Shortcut>ctrl</Shortcut> + <Shortcut>s</Shortcut> (Windows)
   saves the form
 
+<br />
+
 ### Sequence Editor
+
+- <Shortcut>⌘</Shortcut> + <Shortcut>s</Shortcut> (MacOS) or <Shortcut>ctrl</Shortcut> + <Shortcut>s</Shortcut> (Windows)
+  saves the sequence

--- a/sidebars.js
+++ b/sidebars.js
@@ -322,6 +322,11 @@ const sidebars = {
       ],
     },
     'glossary',
+    {
+      label: 'Keyboard Shortcuts',
+      type: 'doc',
+      id: 'keyboard-shortcuts',
+    },
   ],
   upgradeGuides: [
     'upgrade-guides/2-11-0-to-2-12-0',


### PR DESCRIPTION
Add a page that documents keyboard shortcuts across Aerie UI. 
- Link in sidebar at bottom below glossary for discoverability
- Separated into sections for different pages and panels
- Adds a `<Shortcut />` component that wraps the `<kbd>` html element with a bit more padding

Future work:
- This list may not be exhaustive. We should continue the round up and add additional shortcuts as they come up
- Could also be useful to add docs around the context menus
- We may consider adding a link to this from within aerie-ui

![image](https://github.com/NASA-AMMOS/aerie-docs/assets/6529667/5bb06145-603d-45a8-a62c-7cf0651c85e4)
