### PR TITLE
Update docs cover page version to 2.14.0

### DIFF
--- a/static/mgss-cover-page.html
+++ b/static/mgss-cover-page.html
@@ -35,7 +35,7 @@
               <td>636.101</td>
               <td>MPSA</td>
               <td>Aerie</td>
-              <td>2.11.1</td>
+              <td>2.14.0</td>
             </tr>
           </tbody>
         </table>

--- a/static/mgss-cover-page.html
+++ b/static/mgss-cover-page.html
@@ -35,7 +35,7 @@
               <td>636.101</td>
               <td>MPSA</td>
               <td>Aerie</td>
-              <td>2.14.0</td>
+              <td id="aerie-version">2.14.0</td>
             </tr>
           </tbody>
         </table>

--- a/static/mgss-cover-page.html
+++ b/static/mgss-cover-page.html
@@ -35,7 +35,7 @@
               <td>636.101</td>
               <td>MPSA</td>
               <td>Aerie</td>
-              <td>2.2.1</td>
+              <td>2.11.1</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
Updates the MGSS cover page used in the PDF docs. In future releases, this will be handled automatically by:

https://github.com/NASA-AMMOS/aerie-release/pull/8