### PR TITLE
Update 2.8.0 Upgrade Docs

### DIFF
--- a/docs/upgrade-guides/2-7-1-to-2-8-0.md
+++ b/docs/upgrade-guides/2-7-1-to-2-8-0.md
@@ -92,7 +92,7 @@ Below are all of the changes to the variables in our `docker-compose.yml` file i
 - aerie_scheduler:
   - removed envvars:  `SCHEDULER_DB`
   - renamed envvars:
-    - `SCHEDULER_DB_SERVER` -> `AERIE_DB_HOST`
+    - `SCHEDULER_DB_SERVER` -> `AERIE_DB_SERVER`
     - `SCHEDULER_DB_PORT` -> `AERIE_DB_PORT`
   - `SCHEDULER_DB_USER` should now be mapped at the envvar `"${SCHEDULER_USERNAME}"`
   - `SCHEDULER_DB_PASSWORD` should now be mapped at the envvar `"${SCHEDULER_PASSWORD}"`
@@ -102,7 +102,7 @@ Below are all of the changes to the variables in our `docker-compose.yml` file i
     - `SCHEDULER_WORKER_DB_USER`
     - `SCHEDULER_WORKER_DB_PASSWORD`
   - renamed envvars:
-    - `SCHEDULER_WORKER_DB_SERVER` -> `AERIE_DB_HOST`
+    - `SCHEDULER_WORKER_DB_SERVER` -> `AERIE_DB_SERVER`
     - `SCHEDULER_WORKER_DB_PORT` -> `AERIE_DB_PORT`
   - added envvars:
     - `SCHEDULER_DB_USER: "${SCHEDULER_USERNAME}"`


### PR DESCRIPTION
Related issue: https://github.com/NASA-AMMOS/aerie/issues/1462

Reflects the actual envvars present in 2.8.0 Scheduler containers

