### PR TITLE
Fix scheduling example docs not committing changes

### DIFF
--- a/docs/scheduling-and-constraints/procedural/scheduling.mdx
+++ b/docs/scheduling-and-constraints/procedural/scheduling.mdx
@@ -111,6 +111,8 @@ class MyActivityEveryHour: Goal {
         mapOf() // assuming it takes no arguments
       )
     }
+
+    plan.commit()
   }
 }
 ```
@@ -130,6 +132,8 @@ public class MyActivityEveryHour implements Goal {
         Map.of()
       );
     }
+
+    plan.commit();
   }
 }
 ```
@@ -162,6 +166,8 @@ class MyActivityEveryHour: Goal {
         mapOf() // assuming it takes no arguments
       )
     }
+
+    plan.commit()
   }
 }
 ```
@@ -184,6 +190,8 @@ public class MyActivityEveryHour implements Goal {
         Map.of()
       );
     }
+
+    plan.commit();
   }
 }
 ```


### PR DESCRIPTION
The couple scheduling example goals should finish with `plan.commit()`. Thanks @pranav-super for catching it.