### PR TITLE
Updated to include new fine-grained hasura function `migrate_plan_to_model`

### DIFF
--- a/docs/deployment/advanced-permissions.mdx
+++ b/docs/deployment/advanced-permissions.mdx
@@ -235,6 +235,7 @@ Any Functions not included here only have coarse-grained control.
 | `get_conflicting_activities` | `get_conflicting_activities`
 | `get_non_conflicting_activities` | `get_non_conflicting_activities`
 | `get_plan_history` | `get_plan_history` |
+| `migrate_plan_to_model` | `migrate_plan_to_model` |
 | `restore_activity_changelog` | `restore_activity_changelog`
 | `restore_snapshot` | `restore_from_snapshot`
 | `set_resolution` | `set_resolution`
@@ -339,6 +340,7 @@ Below are sample Query Variables. These are equivalent to the `user` role's Perm
     "get_conflicting_activities": "NO_CHECK",
     "get_non_conflicting_activities": "NO_CHECK",
     "get_plan_history": "NO_CHECK",
+    "migrate_plan_to_model": "PLAN_OWNER_COLLABORATOR",
     "restore_activity_changelog": "PLAN_OWNER_COLLABORATOR",
     "restore_snapshot": "PLAN_OWNER_COLLABORATOR",
     "set_resolution": "PLAN_OWNER_TARGET",


### PR DESCRIPTION
This PR is a 2-line change to include the new fine-grained hasura function `migrage_plan_to_model` from https://github.com/NASA-AMMOS/aerie/pull/1665. 