### PR TITLE
Use records in scheduling procedure examples

### DIFF
--- a/docs/scheduling-and-constraints/procedural/scheduling/introduction.mdx
+++ b/docs/scheduling-and-constraints/procedural/scheduling/introduction.mdx
@@ -122,7 +122,7 @@ class MyActivityEveryHour: Goal {
 
 ```java
 @SchedulingProcedure
-public class MyActivityEveryHour implements Goal {
+public record MyActivityEveryHour() implements Goal {
   @Override
   public void run(EditablePlan plan) {
     for (final var time: plan.totalBounds().step(Duration.HOUR)) {
@@ -177,7 +177,7 @@ class MyActivityEveryHour: Goal {
 
 ```java
 @SchedulingProcedure
-public class MyActivityEveryHour implements Goal {
+public record MyActivityEveryHour() implements Goal {
   @Override
   public void run(EditablePlan plan) {
     // This produces a Booleans profile that is true at the instant of a MyActivity directive.


### PR DESCRIPTION
Scheduling procedures are currently required to be records; the examples implied that they could be regular Java classes.